### PR TITLE
Improve icon search

### DIFF
--- a/app/Http/Livewire/IconSearch.php
+++ b/app/Http/Livewire/IconSearch.php
@@ -6,6 +6,7 @@ namespace App\Http\Livewire;
 
 use App\Models\Icon;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
 
 final class IconSearch extends Component
@@ -30,9 +31,26 @@ final class IconSearch extends Component
     {
         return view('livewire.icon-search', [
             'total' => Icon::count(),
-            'icons' => Icon::search($this->search)
-                ->take($this->search ? 500 : 72)
-                ->get(),
+            'icons' => $this->icons(),
         ]);
+    }
+
+    protected function icons(): Collection
+    {
+        if ($this->shouldShowRandomIcons()) {
+            return Icon::query()
+                ->inRandomOrder()
+                ->take(72)
+                ->get();
+        }
+
+        return Icon::search($this->search)
+            ->take(500)
+            ->get();
+    }
+
+    protected function shouldShowRandomIcons(): bool
+    {
+        return empty(trim($this->search));
     }
 }

--- a/app/Models/Icon.php
+++ b/app/Models/Icon.php
@@ -34,7 +34,9 @@ final class Icon extends Model
 
     public static function relatedIcons(self $icon): Collection
     {
-        return static::search($icon->keywords)->get();
+        return static::search($icon->keywords)
+            ->get()
+            ->where('id', '!=', $icon->id);
     }
 
     public function getRouteKeyName(): string

--- a/resources/views/livewire/icon-search.blade.php
+++ b/resources/views/livewire/icon-search.blade.php
@@ -8,7 +8,7 @@
                 autocorrect="off"
                 spellcheck="false"
                 type="text"
-                placeholder="Search all {{ $total }} Blade icons ..."
+                placeholder="Search all {{ number_format($total) }} Blade icons ..."
                 wire:model.debounce.400ms="search"
             >
 


### PR DESCRIPTION
### Make total icon count easier to read

**Before**
![image](https://user-images.githubusercontent.com/13331388/117493941-f1eef000-af73-11eb-8515-c03af1155d57.png)

**After**
![image](https://user-images.githubusercontent.com/13331388/117493761-b5bb8f80-af73-11eb-8aaf-ec93e078b940.png)

---

### Exclude current item from similar icons

Examle https://blade-ui-kit.com/blade-icons/bi-credit-card-2-back-fill

**Before**
![image](https://user-images.githubusercontent.com/13331388/117493838-cff56d80-af73-11eb-9733-cee1b602ad8e.png)

**After**
![image](https://user-images.githubusercontent.com/13331388/117493884-dd125c80-af73-11eb-8020-08b59ce1e5d7.png)

---

### Show random icons if nothing is search

---
Fixes #26 