### PR TITLE
simpleicons major version upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "codeat3/blade-prime-icons": "^1.5",
         "codeat3/blade-radix-icons": "^1.3",
         "codeat3/blade-rpg-awesome-icons": "^1.2",
-        "codeat3/blade-simple-icons": "^4.0",
+        "codeat3/blade-simple-icons": "^5.0",
         "codeat3/blade-simple-line-icons": "^1.1",
         "codeat3/blade-solar-icons": "^1.1",
         "codeat3/blade-system-uicons": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f51409776e64b9162d3374cd79df634d",
+    "content-hash": "2515259a1bf4c47b28dae627739007ae",
     "packages": [
         {
             "name": "actb/blade-github-octicons",
@@ -1260,16 +1260,16 @@
         },
         {
             "name": "codeat3/blade-carbon-icons",
-            "version": "2.27.0",
+            "version": "2.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/codeat3/blade-carbon-icons.git",
-                "reference": "26eb43c7d6fda66d7f8612796011869fcb8a1f02"
+                "reference": "e512754f4640862f01262497fbfb58eb35563504"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeat3/blade-carbon-icons/zipball/26eb43c7d6fda66d7f8612796011869fcb8a1f02",
-                "reference": "26eb43c7d6fda66d7f8612796011869fcb8a1f02",
+                "url": "https://api.github.com/repos/codeat3/blade-carbon-icons/zipball/e512754f4640862f01262497fbfb58eb35563504",
+                "reference": "e512754f4640862f01262497fbfb58eb35563504",
                 "shasum": ""
             },
             "require": {
@@ -1320,7 +1320,7 @@
             ],
             "support": {
                 "issues": "https://github.com/codeat3/blade-carbon-icons/issues",
-                "source": "https://github.com/codeat3/blade-carbon-icons/tree/2.27.0"
+                "source": "https://github.com/codeat3/blade-carbon-icons/tree/2.28.0"
             },
             "funding": [
                 {
@@ -1328,7 +1328,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-24T17:03:49+00:00"
+            "time": "2024-07-01T13:19:18+00:00"
         },
         {
             "name": "codeat3/blade-clarity-icons",
@@ -3967,16 +3967,16 @@
         },
         {
             "name": "codeat3/blade-simple-icons",
-            "version": "4.4.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/codeat3/blade-simple-icons.git",
-                "reference": "0cbc5b6b5b2d04db50ff6da31de4187728a075cf"
+                "reference": "e5726e93bc47650b2017630e6f0a64f5a9f92844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeat3/blade-simple-icons/zipball/0cbc5b6b5b2d04db50ff6da31de4187728a075cf",
-                "reference": "0cbc5b6b5b2d04db50ff6da31de4187728a075cf",
+                "url": "https://api.github.com/repos/codeat3/blade-simple-icons/zipball/e5726e93bc47650b2017630e6f0a64f5a9f92844",
+                "reference": "e5726e93bc47650b2017630e6f0a64f5a9f92844",
                 "shasum": ""
             },
             "require": {
@@ -4026,7 +4026,7 @@
             ],
             "support": {
                 "issues": "https://github.com/codeat3/blade-simple-icons/issues",
-                "source": "https://github.com/codeat3/blade-simple-icons/tree/4.4.0"
+                "source": "https://github.com/codeat3/blade-simple-icons/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4034,7 +4034,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-24T17:05:44+00:00"
+            "time": "2024-07-01T13:21:09+00:00"
         },
         {
             "name": "codeat3/blade-simple-line-icons",


### PR DESCRIPTION
- upgrading `codeat3/blade-simple-icons` to newer major version