### PR TITLE
feat: add robertboes/selfh.st icon set

### DIFF
--- a/app/Console/Commands/ImportIcons.php
+++ b/app/Console/Commands/ImportIcons.php
@@ -66,6 +66,7 @@ final class ImportIcons extends Command
                         'name' => $set['prefix'].'-'.$icon,
                         'outlined' => $this->isOutlined($icon, $iconSet->outline_rule),
                         'keywords' => $this->keywords($icon, $iconSet->ignore_rule),
+                        'overwrite_fill' => $this->hasFillOverwritten($icon, $iconSet->overwrite_fill),
                     ]);
                 }
             }
@@ -80,6 +81,15 @@ final class ImportIcons extends Command
     }
 
     private function isOutlined(string $string, ?string $rule): bool
+    {
+        if ($rule === null) {
+            return false;
+        }
+
+        return Str::of($string)->match($rule)->isNotEmpty();
+    }
+
+    private function hasFillOverwritten(string $string, ?string $rule): bool
     {
         if ($rule === null) {
             return false;

--- a/app/Models/IconSet.php
+++ b/app/Models/IconSet.php
@@ -707,6 +707,14 @@ final class IconSet extends Model
             'ignore_rule' => null,
             'outline_rule' => null,
         ],
+        [
+            'id' => 89,
+            'name' => 'selfhst-icons',
+            'repository' => 'https://github.com/RobertBoes/blade-selfhst-icons',
+            'composer' => 'robertboes/blade-selfhst-icons',
+            'ignore_rule' => null,
+            'outline_rule' => null,
+        ],
     ];
 
     public function name(): string

--- a/app/Models/IconSet.php
+++ b/app/Models/IconSet.php
@@ -105,7 +105,7 @@ final class IconSet extends Model
         //     'composer' => 'actb/blade-github-octicons',
         //     'ignore_rule' => '/-\d{2}$/', // 16|24
         //     'outline_rule' => null,
-        'overwrite_fill' => null,
+        //     'overwrite_fill' => null,
         // ],
         [
             'id' => 11,

--- a/app/Models/IconSet.php
+++ b/app/Models/IconSet.php
@@ -24,6 +24,7 @@ final class IconSet extends Model
             'composer' => 'blade-ui-kit/blade-heroicons',
             'ignore_rule' => '/^(?:o|s)-/',
             'outline_rule' => '/^o-/',
+            'overwrite_fill' => null,
         ],
         [
             'id' => 2,
@@ -32,6 +33,7 @@ final class IconSet extends Model
             'composer' => 'blade-ui-kit/blade-zondicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 3,
@@ -40,6 +42,7 @@ final class IconSet extends Model
             'composer' => 'davidhsianturi/blade-bootstrap-icons',
             'ignore_rule' => '/-fill$/',
             'outline_rule' => '/.*(?<!-fill)$/',
+            'overwrite_fill' => null,
         ],
         [
             'id' => 4,
@@ -48,6 +51,7 @@ final class IconSet extends Model
             'composer' => 'khatabwedaa/blade-css-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 5,
@@ -56,6 +60,7 @@ final class IconSet extends Model
             'composer' => 'hasnayeen/blade-eva-icons',
             'ignore_rule' => '/-outline$/',
             'outline_rule' => '/-outline$/',
+            'overwrite_fill' => null,
         ],
         [
             'id' => 6,
@@ -64,6 +69,7 @@ final class IconSet extends Model
             'composer' => 'brunocfalcao/blade-feather-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 7,
@@ -72,6 +78,7 @@ final class IconSet extends Model
             'composer' => 'owenvoke/blade-fontawesome',
             'ignore_rule' => null, //fab
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 8,
@@ -80,6 +87,7 @@ final class IconSet extends Model
             'composer' => 'owenvoke/blade-fontawesome',
             'ignore_rule' => null, //far
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 9,
@@ -88,6 +96,7 @@ final class IconSet extends Model
             'composer' => 'owenvoke/blade-fontawesome',
             'ignore_rule' => null, //fas
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         // [
         //     'id' => 10,
@@ -96,6 +105,7 @@ final class IconSet extends Model
         //     'composer' => 'actb/blade-github-octicons',
         //     'ignore_rule' => '/-\d{2}$/', // 16|24
         //     'outline_rule' => null,
+        'overwrite_fill' => null,
         // ],
         [
             'id' => 11,
@@ -104,6 +114,7 @@ final class IconSet extends Model
             'composer' => 'faisal50x/blade-ionicons',
             'ignore_rule' => '/-(?:outline|sharp)$/',
             'outline_rule' => '/-outline$/',
+            'overwrite_fill' => null,
         ],
         [
             'id' => 13,
@@ -112,6 +123,7 @@ final class IconSet extends Model
             'composer' => 'andreiio/blade-remix-icon',
             'ignore_rule' => '/-(?:line|fill)$/',
             'outline_rule' => '/-line$/',
+            'overwrite_fill' => null,
         ],
         [
             'id' => 14,
@@ -120,6 +132,7 @@ final class IconSet extends Model
             'composer' => 'secondnetwork/blade-tabler-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 15,
@@ -128,6 +141,7 @@ final class IconSet extends Model
             'composer' => 'owenvoke/blade-entypo',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 16,
@@ -136,6 +150,7 @@ final class IconSet extends Model
             'composer' => 'mallardduck/blade-boxicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 17,
@@ -144,6 +159,7 @@ final class IconSet extends Model
             'composer' => 'mallardduck/blade-boxicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 18,
@@ -152,6 +168,7 @@ final class IconSet extends Model
             'composer' => 'mallardduck/blade-boxicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 19,
@@ -160,6 +177,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-simple-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 20,
@@ -168,6 +186,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-google-material-design-icons',
             'ignore_rule' => null,
             'outline_rule' => '/-o$/',
+            'overwrite_fill' => null,
         ],
         [
             'id' => 21,
@@ -176,6 +195,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-codicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 22,
@@ -184,6 +204,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-cryptocurrency-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 23,
@@ -192,6 +213,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-eos-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 24,
@@ -200,6 +222,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-evil-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 25,
@@ -208,6 +231,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-file-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 26,
@@ -216,6 +240,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-fontaudio',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 27,
@@ -224,6 +249,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-weather-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 28,
@@ -232,6 +258,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-vaadin-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 29,
@@ -240,6 +267,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-unicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 30,
@@ -248,6 +276,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-typicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 31,
@@ -256,6 +285,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-teeny-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 32,
@@ -264,6 +294,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-system-uicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 33,
@@ -272,6 +303,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-rpg-awesome-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 34,
@@ -280,6 +312,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-radix-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 35,
@@ -288,6 +321,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-pixelarticons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 36,
@@ -296,6 +330,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-phosphor-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 37,
@@ -304,6 +339,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-microns',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 38,
@@ -312,6 +348,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-jam-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 39,
@@ -320,6 +357,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-ikonate',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 40,
@@ -328,6 +366,7 @@ final class IconSet extends Model
             'composer' => 'andreiio/blade-iconoir',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 41,
@@ -336,6 +375,7 @@ final class IconSet extends Model
             'composer' => 'itsmalikjones/blade-iconic',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 42,
@@ -344,6 +384,7 @@ final class IconSet extends Model
             'composer' => 'nerdroid23/blade-icomoon',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 43,
@@ -352,6 +393,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-fluentui-system-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 44,
@@ -360,6 +402,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-forkawesome',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 45,
@@ -368,6 +411,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-line-awesome-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 46,
@@ -376,6 +420,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-clarity-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 47,
@@ -384,6 +429,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-iconpark',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 48,
@@ -392,6 +438,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-ant-design-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 49,
@@ -400,6 +447,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-majestic-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 50,
@@ -408,6 +456,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-akar-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 51,
@@ -416,6 +465,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-fontisto-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 52,
@@ -424,6 +474,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-bytesize-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 53,
@@ -432,6 +483,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-coolicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 54,
@@ -440,6 +492,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-simple-line-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 55,
@@ -448,6 +501,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-mono-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 56,
@@ -456,6 +510,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-govicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 57,
@@ -464,6 +519,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-uiw-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 58,
@@ -472,6 +528,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-pepicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 59,
@@ -480,6 +537,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-game-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 61,
@@ -488,6 +546,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-carbon-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 62,
@@ -496,6 +555,7 @@ final class IconSet extends Model
             'composer' => 'troccoli/blade-health-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 63,
@@ -504,6 +564,7 @@ final class IconSet extends Model
             'composer' => 'mallardduck/blade-lucide-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 64,
@@ -512,6 +573,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-grommet-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 65,
@@ -520,6 +582,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-elusive-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 66,
@@ -528,6 +591,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-maki-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 67,
@@ -536,6 +600,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-academicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 68,
@@ -544,6 +609,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-emblemicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 69,
@@ -552,6 +618,7 @@ final class IconSet extends Model
             'composer' => 'eduard9969/blade-polaris-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 70,
@@ -560,6 +627,7 @@ final class IconSet extends Model
             'composer' => 'saade/blade-iconsax',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 71,
@@ -568,6 +636,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-devicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 72,
@@ -576,6 +645,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/prime-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 73,
@@ -584,6 +654,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/gala-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 74,
@@ -592,6 +663,7 @@ final class IconSet extends Model
             'composer' => 'mckenziearts/blade-untitledui-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 75,
@@ -600,6 +672,7 @@ final class IconSet extends Model
             'composer' => 'log1x/blade-filetype-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 76,
@@ -608,6 +681,7 @@ final class IconSet extends Model
             'composer' => 'postare/blade-mdi',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 77,
@@ -616,6 +690,7 @@ final class IconSet extends Model
             'composer' => 'themesberg/flowbite-blade-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 78,
@@ -624,6 +699,7 @@ final class IconSet extends Model
             'composer' => 'mckenziearts/blade-untitledui-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 79,
@@ -632,6 +708,7 @@ final class IconSet extends Model
             'composer' => 'mansoor/blade-lets-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 80,
@@ -640,6 +717,7 @@ final class IconSet extends Model
             'composer' => 'afatmustafa/blade-hugeicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 81,
@@ -648,6 +726,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-gravity-ui-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 82,
@@ -656,6 +735,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-memory-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 83,
@@ -664,6 +744,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-element-plus-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 84,
@@ -672,6 +753,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-humbleicons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
 
         ],
         [
@@ -681,6 +763,7 @@ final class IconSet extends Model
             'composer' => 'codeat3/blade-solar-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
 
         ],
         [
@@ -690,6 +773,7 @@ final class IconSet extends Model
             'composer' => 'johan-boshoff/blade-car-makes-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 87,
@@ -698,6 +782,7 @@ final class IconSet extends Model
             'composer' => 'maiden-voyage-software/blade-emojis',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 88,
@@ -706,6 +791,7 @@ final class IconSet extends Model
             'composer' => 'daljo25/blade-pixelicon-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => null,
         ],
         [
             'id' => 89,
@@ -714,6 +800,7 @@ final class IconSet extends Model
             'composer' => 'robertboes/blade-selfhst-icons',
             'ignore_rule' => null,
             'outline_rule' => null,
+            'overwrite_fill' => '/-light$/',
         ],
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
         "owenvoke/blade-entypo": "^2.0",
         "owenvoke/blade-fontawesome": "^2.6",
         "postare/blade-mdi": "^1.0",
+        "robertboes/blade-selfhst-icons": "^0.2.1",
         "saade/blade-iconsax": "^1.2",
         "secondnetwork/blade-tabler-icons": "^3.28",
         "spatie/laravel-ignition": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac7068f361c50c73f71cb7394d859854",
+    "content-hash": "7c00a400f8d21a2b01f15f39a0856277",
     "packages": [
         {
             "name": "afatmustafa/blade-hugeicons",
@@ -9382,6 +9382,65 @@
             "time": "2025-12-14T04:43:48+00:00"
         },
         {
+            "name": "robertboes/blade-selfhst-icons",
+            "version": "v0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RobertBoes/blade-selfhst-icons.git",
+                "reference": "066c7ec23082decede47da0a53ef62d2f10de99e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RobertBoes/blade-selfhst-icons/zipball/066c7ec23082decede47da0a53ef62d2f10de99e",
+                "reference": "066c7ec23082decede47da0a53ef62d2f10de99e",
+                "shasum": ""
+            },
+            "require": {
+                "blade-ui-kit/blade-icons": "^1.6",
+                "illuminate/support": "^11.0 || ^12.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^9.0 || ^10.0",
+                "phpunit/phpunit": "^10.5 || ^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "BladeUI\\SelfhstIcons\\BladeSelfhstIconsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BladeUI\\SelfhstIcons\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Boes"
+                }
+            ],
+            "description": "A package to easily make use of selfh.st Icons in your Laravel Blade views.",
+            "homepage": "https://github.com/RobertBoes/blade-selfhst-icons",
+            "keywords": [
+                "blade",
+                "icons",
+                "laravel",
+                "selfh.st"
+            ],
+            "support": {
+                "issues": "https://github.com/RobertBoes/blade-selfhst-icons/issues",
+                "source": "https://github.com/RobertBoes/blade-selfhst-icons/tree/v0.2.1"
+            },
+            "time": "2026-03-30T07:37:13+00:00"
+        },
+        {
             "name": "saade/blade-iconsax",
             "version": "v1.2.2",
             "source": {
@@ -14862,5 +14921,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/database/migrations/2026_03_31_095623_add_overwrite_fill_to_icons.php
+++ b/database/migrations/2026_03_31_095623_add_overwrite_fill_to_icons.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('icons', function (Blueprint $table) {
+            $table->boolean('overwrite_fill')->default(false)->after('outlined');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('icons', function (Blueprint $table) {
+            $table->dropColumn('overwrite_fill');
+        });
+    }
+};

--- a/resources/views/components/icon-link.blade.php
+++ b/resources/views/components/icon-link.blade.php
@@ -2,7 +2,7 @@
     href="{{ route('blade-icon', $icon) }}"
     class="flex flex-col items-center justify-between w-full h-full p-3 transition duration-300 ease-in-out border border-gray-200 text-gray-500 rounded-lg hover:text-scarlet-500 hover:shadow-md"
 >
-    {{ svg($icon->name, 'w-8 h-8') }}
+    {{ svg($icon->name, 'w-8 h-8' . $icon->overwrite_fill ? ' !fill-gray-300 *:!fill-gray-300' : '') }}
 
     <span class="text-center truncate max-w-full mt-3">
         {{ $icon->name }}


### PR DESCRIPTION
Follow-up from driesvints/blade-icons#283

<img width="1543" height="1063" alt="Selfh.st Icons" src="https://github.com/user-attachments/assets/9e61dd79-8db8-46aa-9f53-d44cefd66292" />

Just one note, as is visible in the screenshot: The light icons from selfh.st are `#fff`, so it looks like the icons aren't working, but this is due to the background having the same color. I can take a look at addressing that, if wanted.