### PR TITLE
Fix icon fill

### DIFF
--- a/app/Models/Icon.php
+++ b/app/Models/Icon.php
@@ -22,6 +22,7 @@ final class Icon extends Model
     {
         return [
             'keywords' => 'array',
+            'overwrite_fill' => 'boolean',
         ];
     }
 

--- a/resources/views/components/icon-link.blade.php
+++ b/resources/views/components/icon-link.blade.php
@@ -2,7 +2,7 @@
     href="{{ route('blade-icon', $icon) }}"
     class="flex flex-col items-center justify-between w-full h-full p-3 transition duration-300 ease-in-out border border-gray-200 text-gray-500 rounded-lg hover:text-scarlet-500 hover:shadow-md"
 >
-    {{ svg($icon->name, 'w-8 h-8' . $icon->overwrite_fill ? ' !fill-gray-300 *:!fill-gray-300' : '') }}
+    {{ svg($icon->name, 'w-8 h-8' . ($icon->overwrite_fill ? ' !fill-gray-300 *:!fill-gray-300' : '')) }}
 
     <span class="text-center truncate max-w-full mt-3">
         {{ $icon->name }}


### PR DESCRIPTION
Accidentally introduced an issue in #424; all the icons now have a fill. This was due to `'w-8 h-8' . $icon->overwrite_fill ? ' !fill-gray-300 *:!fill-gray-300' : ''` instead of `'w-8 h-8' . ($icon->overwrite_fill ? ' !fill-gray-300 *:!fill-gray-300' : '')`, whoops 😅 